### PR TITLE
Fix saving media on Android using file:///

### DIFF
--- a/src/android/PhotoLibraryService.java
+++ b/src/android/PhotoLibraryService.java
@@ -44,22 +44,22 @@ public class PhotoLibraryService {
   //int cacheSize = 4 * 1024 * 1024; // 4MB
   //private LruCache<String, byte[]> imageCache = new LruCache<String, byte[]>(cacheSize);
 
-	protected PhotoLibraryService() {
+  protected PhotoLibraryService() {
     dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm a z");
-	}
+  }
 
   public static final String PERMISSION_ERROR = "Permission Denial: This application is not allowed to access Photo data.";
 
-	public static PhotoLibraryService getInstance() {
-		if (instance == null) {
-			synchronized (PhotoLibraryService.class) {
-				if (instance == null) {
-					instance = new PhotoLibraryService();
-				}
-			}
-		}
-		return instance;
-	}
+  public static PhotoLibraryService getInstance() {
+    if (instance == null) {
+      synchronized (PhotoLibraryService.class) {
+        if (instance == null) {
+          instance = new PhotoLibraryService();
+        }
+      }
+    }
+    return instance;
+  }
 
   public void getLibrary(Context context, MyRunnable partialCallback, MyRunnable completion) throws JSONException {
 
@@ -565,12 +565,19 @@ public class PhotoLibraryService {
 
     } else {
 
-      String sourceUrl = url.replace("file:///", "");
       String extension = url.contains(".") ? url.substring(url.lastIndexOf(".")) : "";
       targetFile = getImageFileName(albumDirectory, extension);
 
-      InputStream is = cordova.getActivity().getApplicationContext().getAssets().open(sourceUrl);
+      InputStream is;
       FileOutputStream os = new FileOutputStream(targetFile);
+
+      if(url.startsWith("file:///android_asset/")) {
+        String assetUrl = url.replace("file:///android_asset/", "");
+        is = cordova.getActivity().getApplicationContext().getAssets().open(assetUrl);
+      } else {
+        File sourceFile = new File(new URI(url));
+        is = new FileInputStream(sourceFile);
+      }
 
       copyStream(is, os);
 

--- a/src/android/PhotoLibraryService.java
+++ b/src/android/PhotoLibraryService.java
@@ -565,11 +565,11 @@ public class PhotoLibraryService {
 
     } else {
 
+      String sourceUrl = url.replace("file:///", "");
       String extension = url.contains(".") ? url.substring(url.lastIndexOf(".")) : "";
       targetFile = getImageFileName(albumDirectory, extension);
 
-      File sourceFile = new File(new URI(url));
-      FileInputStream is = new FileInputStream(sourceFile);
+      InputStream is = cordova.getActivity().getApplicationContext().getAssets().open(sourceUrl);
       FileOutputStream os = new FileOutputStream(targetFile);
 
       copyStream(is, os);


### PR DESCRIPTION
This is a fix to allow the saving of media from the application to the gallery.

The existing code seems to look for the file within the Android filesystem, rather than in the application. So, when I call cordova.plugins.photoLibrary.saveImage("file:///www/img/test.jpg"), it will look for a folder named www in the root of the filesystem, and so will never find the file I'm looking for.

Instead we need to look within the application's assets folder, which is where Cordova stores all of its files, which is what this PR does.