### PR TITLE
Load newest pictures first

### DIFF
--- a/src/android/PhotoLibraryService.java
+++ b/src/android/PhotoLibraryService.java
@@ -276,7 +276,7 @@ public class PhotoLibraryService {
       columnValues.add("" + columns.getString(column));
     }
 
-    final String sortOrder = MediaStore.Images.Media.DATE_TAKEN;
+    final String sortOrder = MediaStore.Images.Media.DATE_TAKEN + " DESC";
 
     final Cursor cursor = context.getContentResolver().query(
       collection,

--- a/src/ios/PhotoLibraryService.swift
+++ b/src/ios/PhotoLibraryService.swift
@@ -46,7 +46,7 @@ final class PhotoLibraryService {
 
     fileprivate init() {
         fetchOptions = PHFetchOptions()
-        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
         //fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
         if #available(iOS 9.0, *) {
             fetchOptions.includeAssetSourceTypes = [.typeUserLibrary, .typeiTunesSynced, .typeCloudShared]


### PR DESCRIPTION
As mentioned in #68, currently you get the oldest pictures first when using `getLibrary()`.

I believe that for most people and apps it makes more sense to get the newest pictures first because that's usually what the user wants to see.

Ideally this would be configurable in the options.