### PR TITLE
Update cordova-plugin-file dependency to 6.0.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,5 +49,5 @@
             <runs />
         </js-module>
     </platform>
-    <dependency id="cordova-plugin-file" version="^5.0.0"/>
+    <dependency id="cordova-plugin-file" version="^6.0.1"/>
 </plugin>


### PR DESCRIPTION
### Platform affected

- iOS
- Android

### What does this PR do?

Change cordova-plugin-file dependency to `6.0.1`.

This PR solves #111 .

### What testing has been done on this change?

Has been added to project and tested on :
- iOS Simulator 11.3
- Android Simulator 8.1
