### PR TITLE
Fix timezone to utc on android devices

### DIFF
--- a/src/android/PhotoLibraryService.java
+++ b/src/android/PhotoLibraryService.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.TimeZone;
 
 public class PhotoLibraryService {
 
@@ -48,6 +49,7 @@ public class PhotoLibraryService {
 
   protected PhotoLibraryService() {
     dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   public static final String PERMISSION_ERROR = "Permission Denial: This application is not allowed to access Photo data.";


### PR DESCRIPTION
I've got a bug on android device using ionic native wrapper and this plugin.
Using getTime() on creationDate field return me date in my timezone but supposed as UTC.
Fixing timezone to utc in date formatting helps resolving this issue.