### PR TITLE
Replacement of depreciated methods with new ways to save photos and videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please write tests for your contribution.
 
 # Install
 
-    cordova plugin add cordova-plugin-photo-library --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="To choose photos" --save
+    cordova plugin add https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="Acessar Galeria para salvar arquivos" --save
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please write tests for your contribution.
 
 # Install
 
-    cordova plugin add cordova-plugin-photo-library --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="To choose photos" --save
+    cordova plugin add https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="To choose photos" --save
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please write tests for your contribution.
 
 # Install
 
-    cordova plugin add https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="To choose photos" --save
+    cordova plugin add cordova-plugin-photo-library --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="To choose photos" --save
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-photo-library",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Plugin that just gets photos from the gallery",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git"
+    "url": "git+https://github.com/terikon/cordova-plugin-photo-library.git"
   },
   "author": {
     "name": "Roman Viskin",
@@ -21,9 +21,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git/issues"
+    "url": "https://github.com/terikon/cordova-plugin-photo-library/issues"
   },
-  "homepage": "https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git#readme",
+  "homepage": "https://github.com/terikon/cordova-plugin-photo-library#readme",
   "devDependencies": {
     "eslint": "^3.14.1",
     "@types/cordova": "^0.0.34",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/terikon/cordova-plugin-photo-library.git"
+    "url": "git+https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git"
   },
   "author": {
     "name": "Roman Viskin",
@@ -21,9 +21,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/terikon/cordova-plugin-photo-library/issues"
+    "url": "https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git/issues"
   },
-  "homepage": "https://github.com/terikon/cordova-plugin-photo-library#readme",
+  "homepage": "https://github.com/joaoduartemariucio/cordova-plugin-photo-library.git#readme",
   "devDependencies": {
     "eslint": "^3.14.1",
     "@types/cordova": "^0.0.34",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-photo-library" version="2.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-photo-library" version="2.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Photo Library</name>
     <js-module src="www/PhotoLibrary.js" name="PhotoLibrary">
         <clobbers target="cordova.plugins.photoLibrary" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
         <source-file src="src/ios/PhotoLibraryProtocol.swift" />
         <source-file src="src/ios/PhotoLibraryService.swift" />
         <source-file src="src/ios/PhotoLibraryGetLibraryOptions.swift" />
-        <dependency id="cordova-plugin-add-swift-support" version="1.6.0"/>
+        <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
     </platform>
     <platform name="browser">
         <config-file target="config.xml" parent="/*">
@@ -49,5 +49,5 @@
             <runs />
         </js-module>
     </platform>
-    <dependency id="cordova-plugin-file" version="^5.0.0"/>
+    <dependency id="cordova-plugin-file" version="6.0.1"/>
 </plugin>

--- a/src/ios/PhotoLibrary.swift
+++ b/src/ios/PhotoLibrary.swift
@@ -240,12 +240,12 @@ import Foundation
             let url = command.arguments[0] as! String
             let album = command.arguments[1] as! String
 
-            service.saveImage(url, album: album) { (libraryItem: NSDictionary?, error: String?) in
+            service.saveImage(url, album: album) { (url: URL?, error: String?) in
                 if (error != nil) {
                     let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: error)
                     self.commandDelegate!.send(pluginResult, callbackId: command.callbackId)
                 } else {
-                    let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: libraryItem as! [String: AnyObject]?)
+                    let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK)
                     self.commandDelegate!.send(pluginResult, callbackId: command.callbackId	)
                 }
             }

--- a/src/ios/PhotoLibraryService.swift
+++ b/src/ios/PhotoLibraryService.swift
@@ -489,17 +489,25 @@ final class PhotoLibraryService {
                     completion(nil, "Could not write image to album: \(String(describing: error))")
                     return
                 }
-                
                 if success {
                     let newCollection = self.fetchAssetCollectionWithAlbumName(albumName: album)
-                    self.insertImage(url: sourceData, intoAssetCollection: newCollection!)
-                    completion(sourceData, nil)
+                    self.insertImage(url: sourceData, intoAssetCollection: newCollection!, completion: {(success,error) in
+                        if(error != nil && !success){
+                            completion(nil, "Cold not save image to album: \(String(describing: error))")
+                        }else{
+                            completion(sourceData, nil)
+                        }
+                    })
                 }
-                
                 } as? (Bool, Error?) -> Void)
         } else {
-            self.insertImage(url: sourceData, intoAssetCollection: collection!)
-            completion(sourceData, nil)
+            self.insertImage(url: sourceData, intoAssetCollection: collection!, completion: {(success,error) in
+                if(error != nil && !success){
+                    completion(nil, "Cold not save image to album: \(String(describing: error))")
+                }else{
+                    completion(sourceData, nil)
+                }
+            })
         }
     }
 
@@ -519,21 +527,30 @@ final class PhotoLibraryService {
                 
                 if success {
                     let newCollection = self.fetchAssetCollectionWithAlbumName(albumName: album)
-                    self.insertVideo(url: sourceData, intoAssetCollection: newCollection!)
-                    completion(sourceData, nil)
+                    self.insertVideo(url: sourceData, intoAssetCollection: newCollection!,completion: {(success,error) in
+                        if(error != nil && !success){
+                            completion(nil, "Cold not save video to album: \(String(describing: error))")
+                        }else{
+                            completion(sourceData, nil)
+                        }
+                    })
                 }
                 
                 } as? (Bool, Error?) -> Void)
         } else {
-            self.insertVideo(url: sourceData, intoAssetCollection: collection!)
-            completion(sourceData, nil)
+            self.insertVideo(url: sourceData, intoAssetCollection: collection!, completion: {(success,error) in
+                if(error != nil && !success){
+                    completion(nil, "Cold not save video to album: \(String(describing: error))")
+                }else{
+                    completion(sourceData, nil)
+                }
+            })
         }
     }
     
-    func insertImage(url: URL, intoAssetCollection collection : PHAssetCollection) {
+    func insertImage(url: URL, intoAssetCollection collection : PHAssetCollection, completion: @escaping (_ success: Bool, _ error: Error?)->Void) {
         
         PHPhotoLibrary.shared().performChanges({
-            
             let creationRequest = PHAssetCreationRequest.creationRequestForAssetFromImage(atFileURL: url)
             let asset = creationRequest?.placeholderForCreatedAsset
             let request = PHAssetCollectionChangeRequest(for: collection)
@@ -542,13 +559,14 @@ final class PhotoLibraryService {
                 let enumeration: NSArray = [asset!]
                 request!.addAssets(enumeration)
             }
-        });
+        }, completionHandler: {(success, error) in
+            completion(success, error)
+        })
     }
     
-    func insertVideo(url: URL, intoAssetCollection collection : PHAssetCollection) {
+    func insertVideo(url: URL, intoAssetCollection collection : PHAssetCollection, completion: @escaping (_ success: Bool, _ error: Error?)->Void) {
         
         PHPhotoLibrary.shared().performChanges({
-            
             let creationRequest = PHAssetCreationRequest.creationRequestForAssetFromVideo(atFileURL: url)
             let asset = creationRequest?.placeholderForCreatedAsset
             let request = PHAssetCollectionChangeRequest(for: collection)
@@ -557,7 +575,9 @@ final class PhotoLibraryService {
                 let enumeration: NSArray = [asset!]
                 request!.addAssets(enumeration)
             }
-        });
+        }, completionHandler: {(success,error) in
+            completion(success, error)
+        })
     }
     
     func fetchAssetCollectionWithAlbumName(albumName : String) -> PHAssetCollection? {

--- a/src/ios/PhotoLibraryService.swift
+++ b/src/ios/PhotoLibraryService.swift
@@ -1,52 +1,29 @@
 import Photos
 import Foundation
-import AssetsLibrary // TODO: needed for deprecated functionality
+import AssetsLibrary
 import MobileCoreServices
 
-extension PHAsset {
-
-    // Returns original file name, useful for photos synced with iTunes
-    var originalFileName: String? {
-        var result: String?
-
-        // This technique is slow
-        if #available(iOS 9.0, *) {
-            let resources = PHAssetResource.assetResources(for: self)
-            if let resource = resources.first {
-                result = resource.originalFilename
-            }
-        }
-
-        return result
-    }
-
-    var fileName: String? {
-        return self.value(forKey: "filename") as? String
-    }
-
-}
-
 final class PhotoLibraryService {
-
+    
     let fetchOptions: PHFetchOptions!
     let thumbnailRequestOptions: PHImageRequestOptions!
     let imageRequestOptions: PHImageRequestOptions!
     let dateFormatter: DateFormatter!
     let cachingImageManager: PHCachingImageManager!
-
+    
     let contentMode = PHImageContentMode.aspectFill // AspectFit: can be smaller, AspectFill - can be larger. TODO: resize to exact size
-
+    
     var cacheActive = false
-
+    
     let mimeTypes = [
         "flv":  "video/x-flv",
         "mp4":  "video/mp4",
-        "m3u8":	"application/x-mpegURL",
+        "m3u8":    "application/x-mpegURL",
         "ts":   "video/MP2T",
-        "3gp":	"video/3gpp",
-        "mov":	"video/quicktime",
-        "avi":	"video/x-msvideo",
-        "wmv":	"video/x-ms-wmv",
+        "3gp":    "video/3gpp",
+        "mov":    "video/quicktime",
+        "avi":    "video/x-msvideo",
+        "wmv":    "video/x-ms-wmv",
         "gif":  "image/gif",
         "jpg":  "image/jpeg",
         "jpeg": "image/jpeg",
@@ -56,11 +33,11 @@ final class PhotoLibraryService {
     ]
     
     static let PERMISSION_ERROR = "Permission Denial: This application is not allowed to access Photo data."
-
+    
     let dataURLPattern = try! NSRegularExpression(pattern: "^data:.+?;base64,", options: NSRegularExpression.Options(rawValue: 0))
-
+    
     let assetCollectionTypes = [PHAssetCollectionType.album, PHAssetCollectionType.smartAlbum/*, PHAssetCollectionType.moment*/]
-
+    
     fileprivate init() {
         fetchOptions = PHFetchOptions()
         fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
@@ -68,44 +45,44 @@ final class PhotoLibraryService {
         if #available(iOS 9.0, *) {
             fetchOptions.includeAssetSourceTypes = [.typeUserLibrary, .typeiTunesSynced, .typeCloudShared]
         }
-
+        
         thumbnailRequestOptions = PHImageRequestOptions()
         thumbnailRequestOptions.isSynchronous = false
         thumbnailRequestOptions.resizeMode = .exact
         thumbnailRequestOptions.deliveryMode = .highQualityFormat
         thumbnailRequestOptions.version = .current
         thumbnailRequestOptions.isNetworkAccessAllowed = false
-
+        
         imageRequestOptions = PHImageRequestOptions()
         imageRequestOptions.isSynchronous = false
         imageRequestOptions.resizeMode = .exact
         imageRequestOptions.deliveryMode = .highQualityFormat
         imageRequestOptions.version = .current
         imageRequestOptions.isNetworkAccessAllowed = false
-
+        
         dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-
+        
         cachingImageManager = PHCachingImageManager()
     }
-
+    
     class var instance: PhotoLibraryService {
-
+        
         struct SingletonWrapper {
             static let singleton = PhotoLibraryService()
         }
-
+        
         return SingletonWrapper.singleton
-
+        
     }
-
+    
     static func hasPermission() -> Bool {
         return PHPhotoLibrary.authorizationStatus() == .authorized
-
+        
     }
-
+    
     func getLibrary(_ options: PhotoLibraryGetLibraryOptions, completion: @escaping (_ result: [NSDictionary], _ chunkNum: Int, _ isLastChunk: Bool) -> Void) {
-
+        
         if(options.includeCloudData == false) {
             if #available(iOS 9.0, *) {
                 // remove iCloud source type
@@ -131,36 +108,36 @@ final class PhotoLibraryService {
         }
         
         let fetchResult = PHAsset.fetchAssets(with: fetchOptions)
-
-
         
-	// TODO: do not restart caching on multiple calls
-//        if fetchResult.count > 0 {
-//
-//            var assets = [PHAsset]()
-//            fetchResult.enumerateObjects({(asset, index, stop) in
-//                assets.append(asset)
-//            })
-//
-//            self.stopCaching()
-//            self.cachingImageManager.startCachingImages(for: assets, targetSize: CGSize(width: options.thumbnailWidth, height: options.thumbnailHeight), contentMode: self.contentMode, options: self.imageRequestOptions)
-//            self.cacheActive = true
-//        }
-
+        
+        
+        // TODO: do not restart caching on multiple calls
+        //        if fetchResult.count > 0 {
+        //
+        //            var assets = [PHAsset]()
+        //            fetchResult.enumerateObjects({(asset, index, stop) in
+        //                assets.append(asset)
+        //            })
+        //
+        //            self.stopCaching()
+        //            self.cachingImageManager.startCachingImages(for: assets, targetSize: CGSize(width: options.thumbnailWidth, height: options.thumbnailHeight), contentMode: self.contentMode, options: self.imageRequestOptions)
+        //            self.cacheActive = true
+        //        }
+        
         var chunk = [NSDictionary]()
         var chunkStartTime = NSDate()
         var chunkNum = 0
-
+        
         fetchResult.enumerateObjects({ (asset: PHAsset, index, stop) in
-
+            
             let libraryItem = self.assetToLibraryItem(asset: asset, useOriginalFileNames: options.useOriginalFileNames, includeAlbumData: options.includeAlbumData)
-
+            
             chunk.append(libraryItem)
             
             self.getCompleteInfo(libraryItem, completion: { (fullPath) in
                 
                 libraryItem["filePath"] = fullPath
-            
+                
                 if index == fetchResult.count - 1 { // Last item
                     completion(chunk, chunkNum, true)
                 } else if (options.itemsInChunk > 0 && chunk.count == options.itemsInChunk) ||
@@ -216,7 +193,7 @@ final class PhotoLibraryService {
                     }
                     else {
                         let file_url:URL = info!["PHImageFileURLKey"] as! URL
-//                        let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]!
+                        //                        let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]!
                         completion(file_url.relativePath)
                     }
                 }
@@ -234,7 +211,7 @@ final class PhotoLibraryService {
                         let token = info?["PHImageFileSandboxExtensionTokenKey"] as! String
                         let path = token.components(separatedBy: ";").last
                         completion(path)
-                    }                    
+                    }
                 })
             }
             else if(mediaType == "audio") {
@@ -307,59 +284,59 @@ final class PhotoLibraryService {
     }
     
     func getThumbnail(_ photoId: String, thumbnailWidth: Int, thumbnailHeight: Int, quality: Float, completion: @escaping (_ result: PictureData?) -> Void) {
-
+        
         let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [photoId], options: self.fetchOptions)
-
+        
         if fetchResult.count == 0 {
             completion(nil)
             return
         }
-
+        
         fetchResult.enumerateObjects({
             (obj: AnyObject, idx: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
-
+            
             let asset = obj as! PHAsset
-
+            
             self.cachingImageManager.requestImage(for: asset, targetSize: CGSize(width: thumbnailWidth, height: thumbnailHeight), contentMode: self.contentMode, options: self.thumbnailRequestOptions) {
                 (image: UIImage?, imageInfo: [AnyHashable: Any]?) in
-
+                
                 guard let image = image else {
                     completion(nil)
                     return
                 }
-
+                
                 let imageData = PhotoLibraryService.image2PictureData(image, quality: quality)
-
+                
                 completion(imageData)
             }
         })
-
+        
     }
-
+    
     func getPhoto(_ photoId: String, completion: @escaping (_ result: PictureData?) -> Void) {
-
+        
         let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [photoId], options: self.fetchOptions)
-
+        
         if fetchResult.count == 0 {
             completion(nil)
             return
         }
-
+        
         fetchResult.enumerateObjects({
             (obj: AnyObject, idx: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
-
+            
             let asset = obj as! PHAsset
             
             PHImageManager.default().requestImageData(for: asset, options: self.imageRequestOptions) {
                 (imageData: Data?, dataUTI: String?, orientation: UIImageOrientation, info: [AnyHashable: Any]?) in
-
+                
                 guard let image = imageData != nil ? UIImage(data: imageData!) : nil else {
                     completion(nil)
                     return
                 }
-
+                
                 let imageData = PhotoLibraryService.image2PictureData(image, quality: 1.0)
-
+                
                 completion(imageData)
             }
         })
@@ -379,18 +356,18 @@ final class PhotoLibraryService {
             (obj: AnyObject, idx: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
             let asset = obj as! PHAsset
             
-            let mediaType = mimeType.components(separatedBy: "/")[0] 
+            let mediaType = mimeType.components(separatedBy: "/")[0]
             
             if(mediaType == "image") {
                 PHImageManager.default().requestImageData(for: asset, options: self.imageRequestOptions) {
                     (imageData: Data?, dataUTI: String?, orientation: UIImageOrientation, info: [AnyHashable: Any]?) in
-
+                    
                     if(imageData == nil) {
                         completion(nil)
                     }
                     else {
-//                        let file_url:URL = info!["PHImageFileURLKey"] as! URL
-//                        let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]
+                        //                        let file_url:URL = info!["PHImageFileURLKey"] as! URL
+                        //                        let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]
                         completion(imageData!.base64EncodedString())
                     }
                 }
@@ -405,7 +382,7 @@ final class PhotoLibraryService {
                     do {
                         let video_data = try Data(contentsOf: url)
                         let video_base64 = video_data.base64EncodedString()
-//                        let mime_type = self.mimeTypes[url.pathExtension.lowercased()]
+                        //                        let mime_type = self.mimeTypes[url.pathExtension.lowercased()]
                         completion(video_base64)
                     }
                     catch _ {
@@ -431,7 +408,7 @@ final class PhotoLibraryService {
             completion(nil)
             return
         }
-     
+        
         fetchResult.enumerateObjects({
             (obj: AnyObject, idx: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
             
@@ -455,25 +432,25 @@ final class PhotoLibraryService {
         })
     }
     
-
+    
     func stopCaching() {
-
+        
         if self.cacheActive {
             self.cachingImageManager.stopCachingImagesForAllAssets()
             self.cacheActive = false
         }
-
+        
     }
-
+    
     func requestAuthorization(_ success: @escaping () -> Void, failure: @escaping (_ err: String) -> Void ) {
-
+        
         let status = PHPhotoLibrary.authorizationStatus()
-
+        
         if status == .authorized {
             success()
             return
         }
-
+        
         if status == .notDetermined {
             // Ask for permission
             PHPhotoLibrary.requestAuthorization() { (status) -> Void in
@@ -486,7 +463,7 @@ final class PhotoLibraryService {
             }
             return
         }
-
+        
         // Permission was manually denied by user, open settings screen
         let settingsUrl = URL(string: UIApplicationOpenSettingsURLString)
         if let url = settingsUrl {
@@ -496,142 +473,104 @@ final class PhotoLibraryService {
         } else {
             failure("could not open settings url")
         }
-
+        
     }
+    
+    func saveImage(_ url: String, album: String, completion: @escaping (_ url: URL?, _ error: String?)->Void) {
+        
+        let sourceData = URL(string: url)!
+        let collection = fetchAssetCollectionWithAlbumName(albumName: album)
 
-    // TODO: implement with PHPhotoLibrary (UIImageWriteToSavedPhotosAlbum) instead of deprecated ALAssetsLibrary,
-    // as described here: http://stackoverflow.com/questions/11972185/ios-save-photo-in-an-app-specific-album
-    // but first find a way to save animated gif with it.
-    // TODO: should return library item
-    func saveImage(_ url: String, album: String, completion: @escaping (_ libraryItem: NSDictionary?, _ error: String?)->Void) {
-
-        let sourceData: Data
-        do {
-            sourceData = try getDataFromURL(url)
-        } catch {
-            completion(nil, "\(String(describing: error))")
-            return
-        }
-
-        let assetsLibrary = ALAssetsLibrary()
-
-        func saveImage(_ photoAlbum: PHAssetCollection) {
-            assetsLibrary.writeImageData(toSavedPhotosAlbum: sourceData, metadata: nil) { (assetUrl: URL?, error: Error?) in
-
+        if collection == nil {
+            
+            PHPhotoLibrary.shared().performChanges({ PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: album)
+            }, completionHandler: {(success : Bool, error : NSError?) in
                 if error != nil {
                     completion(nil, "Could not write image to album: \(String(describing: error))")
                     return
                 }
-
-                guard let assetUrl = assetUrl else {
-                    completion(nil, "Writing image to album resulted empty asset")
-                    return
+                
+                if success {
+                    let newCollection = self.fetchAssetCollectionWithAlbumName(albumName: album)
+                    self.insertImage(url: sourceData, intoAssetCollection: newCollection!)
+                    completion(sourceData, nil)
                 }
-
-                self.putMediaToAlbum(assetsLibrary, url: assetUrl, album: album, completion: { (error) in
-                    if error != nil {
-                        completion(nil, error)
-                    } else {
-                        let fetchResult = PHAsset.fetchAssets(withALAssetURLs: [assetUrl], options: nil)
-                        var libraryItem: NSDictionary? = nil
-                        if fetchResult.count == 1 {
-                            let asset = fetchResult.firstObject
-                            if let asset = asset {
-                                libraryItem = self.assetToLibraryItem(asset: asset, useOriginalFileNames: false, includeAlbumData: true)
-                            }
-                        }
-                        completion(libraryItem, nil)
-                    }
-                })
-
-            }
+                
+                } as? (Bool, Error?) -> Void)
+        } else {
+            self.insertImage(url: sourceData, intoAssetCollection: collection!)
+            completion(sourceData, nil)
         }
-
-        if let photoAlbum = PhotoLibraryService.getPhotoAlbum(album) {
-            saveImage(photoAlbum)
-            return
-        }
-
-        PhotoLibraryService.createPhotoAlbum(album) { (photoAlbum: PHAssetCollection?, error: String?) in
-
-            guard let photoAlbum = photoAlbum else {
-                completion(nil, error)
-                return
-            }
-
-            saveImage(photoAlbum)
-
-        }
-
     }
 
     func saveVideo(_ url: String, album: String, completion: @escaping (_ url: URL?, _ error: String?)->Void) { // TODO: should return library item
-
-        guard let videoURL = URL(string: url) else {
-            completion(nil, "Could not parse DataURL")
-            return
-        }
-
-        let assetsLibrary = ALAssetsLibrary()
-
-        func saveVideo(_ photoAlbum: PHAssetCollection) {
-
-            // TODO: new way, seems not supports dataURL
-            //            if !UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoURL.relativePath!) {
-            //                completion(url: nil, error: "Provided video is not compatible with Saved Photo album")
-            //                return
-            //            }
-            //            UISaveVideoAtPathToSavedPhotosAlbum(videoURL.relativePath!, nil, nil, nil)
-
-            if !assetsLibrary.videoAtPathIs(compatibleWithSavedPhotosAlbum: videoURL) {
-
-                // TODO: try to convert to MP4 as described here?: http://stackoverflow.com/a/39329155/1691132
-
-                completion(nil, "Provided video is not compatible with Saved Photo album")
-                return
-            }
-
-            assetsLibrary.writeVideoAtPath(toSavedPhotosAlbum: videoURL) { (assetUrl: URL?, error: Error?) in
-
+        
+        let sourceData = URL(string: url)!
+        let collection = fetchAssetCollectionWithAlbumName(albumName: album)
+        
+        if collection == nil {
+            
+            PHPhotoLibrary.shared().performChanges({ PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: album)
+            }, completionHandler: {(success : Bool, error : NSError?) in
                 if error != nil {
-                    completion(nil, "Could not write video to album: \(String(describing: error))")
+                    completion(nil, "Could not write image to album: \(String(describing: error))")
                     return
                 }
-
-                guard let assetUrl = assetUrl else {
-                    completion(nil, "Writing video to album resulted empty asset")
-                    return
+                
+                if success {
+                    let newCollection = self.fetchAssetCollectionWithAlbumName(albumName: album)
+                    self.insertVideo(url: sourceData, intoAssetCollection: newCollection!)
+                    completion(sourceData, nil)
                 }
-
-                self.putMediaToAlbum(assetsLibrary, url: assetUrl, album: album, completion: { (error) in
-                    if error != nil {
-                        completion(nil, error)
-                    } else {
-                        completion(assetUrl, nil)
-                    }
-                })
-            }
-
+                
+                } as? (Bool, Error?) -> Void)
+        } else {
+            self.insertVideo(url: sourceData, intoAssetCollection: collection!)
+            completion(sourceData, nil)
         }
-
-        if let photoAlbum = PhotoLibraryService.getPhotoAlbum(album) {
-            saveVideo(photoAlbum)
-            return
-        }
-
-        PhotoLibraryService.createPhotoAlbum(album) { (photoAlbum: PHAssetCollection?, error: String?) in
-
-            guard let photoAlbum = photoAlbum else {
-                completion(nil, error)
-                return
-            }
-
-            saveVideo(photoAlbum)
-
-        }
-
     }
-
+    
+    func insertImage(url: URL, intoAssetCollection collection : PHAssetCollection) {
+        
+        PHPhotoLibrary.shared().performChanges({
+            
+            let creationRequest = PHAssetCreationRequest.creationRequestForAssetFromImage(atFileURL: url)
+            let asset = creationRequest?.placeholderForCreatedAsset
+            let request = PHAssetCollectionChangeRequest(for: collection)
+            
+            if request != nil && asset != nil {
+                let enumeration: NSArray = [asset!]
+                request!.addAssets(enumeration)
+            }
+        });
+    }
+    
+    func insertVideo(url: URL, intoAssetCollection collection : PHAssetCollection) {
+        
+        PHPhotoLibrary.shared().performChanges({
+            
+            let creationRequest = PHAssetCreationRequest.creationRequestForAssetFromVideo(atFileURL: url)
+            let asset = creationRequest?.placeholderForCreatedAsset
+            let request = PHAssetCollectionChangeRequest(for: collection)
+            
+            if request != nil && asset != nil {
+                let enumeration: NSArray = [asset!]
+                request!.addAssets(enumeration)
+            }
+        });
+    }
+    
+    func fetchAssetCollectionWithAlbumName(albumName : String) -> PHAssetCollection? {
+        
+        let fetchOption = PHFetchOptions()
+        fetchOption.predicate = NSPredicate(format: "title == '" + albumName + "'")
+        
+        let fetchResult = PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.album, subtype: PHAssetCollectionSubtype.albumRegular, options: fetchOption)
+        let collection = fetchResult.firstObject
+        
+        return collection
+    }
+    
     struct PictureData {
         var data: Data
         var mimeType: String
@@ -640,18 +579,18 @@ final class PhotoLibraryService {
     // TODO: currently seems useless
     enum PhotoLibraryError: Error, CustomStringConvertible {
         case error(description: String)
-
+        
         var description: String {
             switch self {
             case .error(let description): return description
             }
         }
     }
-
+    
     fileprivate func getDataFromURL(_ url: String) throws -> Data {
         if url.hasPrefix("data:") {
-
-            guard let match = self.dataURLPattern.firstMatch(in: url, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, url.characters.count)) else { // TODO: firstMatchInString seems to be slow for unknown reason
+            
+            guard let match = self.dataURLPattern.firstMatch(in: url, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, url.count)) else { // TODO: firstMatchInString seems to be slow for unknown reason
                 throw PhotoLibraryError.error(description: "The dataURL could not be parsed")
             }
             let dataPos = match.rangeAt(0).length
@@ -659,59 +598,32 @@ final class PhotoLibraryService {
             guard let decoded = Data(base64Encoded: base64, options: NSData.Base64DecodingOptions(rawValue: 0)) else {
                 throw PhotoLibraryError.error(description: "The dataURL could not be decoded")
             }
-
+            
             return decoded
-
+            
         } else {
-
+            
             guard let nsURL = URL(string: url) else {
                 throw PhotoLibraryError.error(description: "The url could not be decoded: \(url)")
             }
             guard let fileContent = try? Data(contentsOf: nsURL) else {
                 throw PhotoLibraryError.error(description: "The url could not be read: \(url)")
             }
-
+            
             return fileContent
-
+            
         }
     }
-
-    fileprivate func putMediaToAlbum(_ assetsLibrary: ALAssetsLibrary, url: URL, album: String, completion: @escaping (_ error: String?)->Void) {
-
-        assetsLibrary.asset(for: url, resultBlock: { (asset: ALAsset?) in
-
-            guard let asset = asset else {
-                completion("Retrieved asset is nil")
-                return
-            }
-
-            PhotoLibraryService.getAlPhotoAlbum(assetsLibrary, album: album, completion: { (alPhotoAlbum: ALAssetsGroup?, error: String?) in
-
-                if error != nil {
-                    completion("getting photo album caused error: \(String(describing: error))")
-                    return
-                }
-
-                alPhotoAlbum!.add(asset)
-                completion(nil)
-
-            })
-
-        }, failureBlock: { (error: Error?) in
-            completion("Could not retrieve saved asset: \(String(describing: error))")
-        })
-
-    }
-
+    
     fileprivate static func image2PictureData(_ image: UIImage, quality: Float) -> PictureData? {
         //        This returns raw data, but mime type is unknown. Anyway, crodova performs base64 for messageAsArrayBuffer, so there's no performance gain visible
         //        let provider: CGDataProvider = CGImageGetDataProvider(image.CGImage)!
         //        let data = CGDataProviderCopyData(provider)
         //        return data;
-
+        
         var data: Data?
         var mimeType: String?
-
+        
         if (imageHasAlpha(image)){
             data = UIImagePNGRepresentation(image)
             mimeType = data != nil ? "image/png" : nil
@@ -719,86 +631,38 @@ final class PhotoLibraryService {
             data = UIImageJPEGRepresentation(image, CGFloat(quality))
             mimeType = data != nil ? "image/jpeg" : nil
         }
-
+        
         if data != nil && mimeType != nil {
             return PictureData(data: data!, mimeType: mimeType!)
         }
         return nil
     }
-
+    
     fileprivate static func imageHasAlpha(_ image: UIImage) -> Bool {
         let alphaInfo = (image.cgImage)?.alphaInfo
         return alphaInfo == .first || alphaInfo == .last || alphaInfo == .premultipliedFirst || alphaInfo == .premultipliedLast
     }
+}
 
-    fileprivate static func getPhotoAlbum(_ album: String) -> PHAssetCollection? {
-
-        let fetchOptions = PHFetchOptions()
-        fetchOptions.predicate = NSPredicate(format: "title = %@", album)
-        let fetchResult = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumRegular, options: fetchOptions)
-        guard let photoAlbum = fetchResult.firstObject else {
-            return nil
-        }
-
-        return photoAlbum
-
-    }
-
-    fileprivate static func createPhotoAlbum(_ album: String, completion: @escaping (_ photoAlbum: PHAssetCollection?, _ error: String?)->()) {
-
-        var albumPlaceholder: PHObjectPlaceholder?
-
-        PHPhotoLibrary.shared().performChanges({
-
-            let createAlbumRequest = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: album)
-            albumPlaceholder = createAlbumRequest.placeholderForCreatedAssetCollection
-
-        }) { success, error in
-
-            guard let placeholder = albumPlaceholder else {
-                completion(nil, "Album placeholder is nil")
-                return
-            }
-
-            let fetchResult = PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: [placeholder.localIdentifier], options: nil)
-
-            guard let photoAlbum = fetchResult.firstObject else {
-                completion(nil, "FetchResult has no PHAssetCollection")
-                return
-            }
-
-            if success {
-                completion(photoAlbum, nil)
-            }
-            else {
-                completion(nil, "\(String(describing: error))")
+extension PHAsset {
+    
+    // Returns original file name, useful for photos synced with iTunes
+    var originalFileName: String? {
+        var result: String?
+        
+        // This technique is slow
+        if #available(iOS 9.0, *) {
+            let resources = PHAssetResource.assetResources(for: self)
+            if let resource = resources.first {
+                result = resource.originalFilename
             }
         }
+        
+        return result
     }
-
-    fileprivate static func getAlPhotoAlbum(_ assetsLibrary: ALAssetsLibrary, album: String, completion: @escaping (_ alPhotoAlbum: ALAssetsGroup?, _ error: String?)->Void) {
-
-        var groupPlaceHolder: ALAssetsGroup?
-
-        assetsLibrary.enumerateGroupsWithTypes(ALAssetsGroupAlbum, usingBlock: { (group: ALAssetsGroup?, _ ) in
-
-            guard let group = group else { // done enumerating
-                guard let groupPlaceHolder = groupPlaceHolder else {
-                    completion(nil, "Could not find album")
-                    return
-                }
-                completion(groupPlaceHolder, nil)
-                return
-            }
-
-            if group.value(forProperty: ALAssetsGroupPropertyName) as? String == album {
-                groupPlaceHolder = group
-            }
-
-        }, failureBlock: { (error: Error?) in
-            completion(nil, "Could not enumerate assets library")
-        })
-
+    
+    var fileName: String? {
+        return self.value(forKey: "filename") as? String
     }
-
+    
 }

--- a/www/PhotoLibrary.js
+++ b/www/PhotoLibrary.js
@@ -252,14 +252,7 @@ photoLibrary.saveImage = function (url, album, success, error, options) {
   }
 
   cordova.exec(
-    function (libraryItem) {
-      var library = libraryItem ? [libraryItem] : [];
-
-      processLibrary(library, function(library) {
-        success(library[0] || null);
-      }, options);
-
-    },
+    success,
     error,
     'PhotoLibrary',
     'saveImage', [url, album]


### PR DESCRIPTION
I've adapted the plugin so it works on the latest iOS versions before it had several errors when saving images and videos, I just replace the old save mode with the new ones I did tests on several devices tested from iOS 9.0 onwards and it works perfectly.