### PR TITLE
Change cordova-plugin-file dependency constraint

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,5 +49,5 @@
             <runs />
         </js-module>
     </platform>
-    <dependency id="cordova-plugin-file" version="^5.0.0"/>
+    <dependency id="cordova-plugin-file" version=">=5.0.0"/>
 </plugin>


### PR DESCRIPTION
Photo plugin works well with the newest version of cordova-plugin-file
but the dependency constraint does not allow for versions starting from
6.0.0, so this change fixes that.