### PR TITLE
Swift Support Dependency Update

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
         <source-file src="src/ios/PhotoLibraryProtocol.swift" />
         <source-file src="src/ios/PhotoLibraryService.swift" />
         <source-file src="src/ios/PhotoLibraryGetLibraryOptions.swift" />
-        <dependency id="cordova-plugin-add-swift-support" version="1.6.0"/>
+        <dependency id="cordova-plugin-add-swift-support" version="^1.6.0"/>
     </platform>
     <platform name="browser">
         <config-file target="config.xml" parent="/*">


### PR DESCRIPTION
In plugin.xml it only supports version 1.6.0

I was able to change this value to @latest 2.0.2 and everything worked as expected on iOS. So I added the ^ in order to get rid of dependency errors when running.