### PR TITLE
[fix] android app crash when the saveImage method is called

### DIFF
--- a/src/android/PhotoLibraryService.java
+++ b/src/android/PhotoLibraryService.java
@@ -201,18 +201,8 @@ public class PhotoLibraryService {
     saveMedia(context, cordova, url, album, imageMimeToExtension, new FilePathRunnable() {
       @Override
       public void run(String filePath) {
-        try {
-          // Find the saved image in the library and return it as libraryItem
-          String whereClause = MediaStore.MediaColumns.DATA + " = \"" + filePath + "\"";
-          queryLibrary(context, whereClause, new ChunkResultRunnable() {
-            @Override
-            public void run(ArrayList<JSONObject> chunk, int chunkNum, boolean isLastChunk) {
-              completion.run(chunk.size() == 1 ? chunk.get(0) : null);
-            }
-          });
-        } catch (Exception e) {
-          completion.run(null);
-        }
+        JSONObject item = new JSONObject();
+        completion.run(item);
       }
     });
 


### PR DESCRIPTION
When an image is saved in android, queryLibrary is called to return a LibraryItem, currently in android applications this causes the app to close.
We removed those lines of code and return an empty JSONObject.